### PR TITLE
Update oem path to ocm

### DIFF
--- a/src/com/sonymobile/customizationselector/Parser/ModemConfParser.java
+++ b/src/com/sonymobile/customizationselector/Parser/ModemConfParser.java
@@ -13,12 +13,13 @@ public class ModemConfParser {
 
     private static final String LEGACY_PATH = "/etc/customization/modem";
     private static final String MODEM_CONF = "/modem.conf";
-    private static final String OEM_PATH = "/modem-config";
+    private static final String CONF_PATH = "/modem-config";
+    private static final String OEM_PATH = "/ocm";
 
     public static String parseModemConf(String conf) {
         CSLog.d(TAG, "setupFilePaths - configId: " + conf);
 
-        File oemDir = new File(Environment.getOemDirectory() + OEM_PATH);
+        File oemDir = new File(OEM_PATH + CONF_PATH);
         StringBuilder filePath = new StringBuilder();
 
         if (oemDir.exists() && oemDir.isDirectory()) {


### PR DESCRIPTION
Environment.getOemDirectory() returns /oem path which, for us, is mounted as /ocm

Replaces the need of 

https://github.com/whatawurst/android_vendor_sony_lilac/commit/a257fb440d66b99bc023ef2806137dfd0c0a8269

