### PR TITLE
Ensure the required mbn is applied at every boot

### DIFF
--- a/src/com/sonymobile/customizationselector/CustomizationSelectorActivity.java
+++ b/src/com/sonymobile/customizationselector/CustomizationSelectorActivity.java
@@ -1,8 +1,5 @@
 package com.sonymobile.customizationselector;
 
-import static android.view.WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD;
-import static android.view.WindowManager.LayoutParams.TYPE_KEYGUARD_DIALOG;
-
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.AlertDialog.Builder;
@@ -16,6 +13,9 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.util.Log;
+
+import static android.view.WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD;
+import static android.view.WindowManager.LayoutParams.TYPE_KEYGUARD_DIALOG;
 
 public class CustomizationSelectorActivity extends Activity implements OnClickListener {
 
@@ -73,6 +73,8 @@ public class CustomizationSelectorActivity extends Activity implements OnClickLi
             startDialog();
             return;
         }
+
+        mConfigurator.reApplyModem();
 
         disableActivity();
         Intent intent = new Intent();

--- a/src/com/sonymobile/customizationselector/ModemSwitcher.java
+++ b/src/com/sonymobile/customizationselector/ModemSwitcher.java
@@ -213,7 +213,6 @@ public class ModemSwitcher {
         }
 
         if (hasModemConfig) {
-            String modemFileName;
             try {
                 if (getCurrentModemConfig().equals(modemConfig)) {
                     CSLog.e(TAG, "Selected modem configuration is already active!: " + modemConfig);
@@ -223,7 +222,7 @@ public class ModemSwitcher {
                 CSLog.w(TAG, "Unable to read out current configuration");
             }
 
-            modemFileName = new File(modemConfig).getName();
+            String modemFileName = new File(modemConfig).getName();
             if (writeModemToMiscTA(modemFileName)) {
                 CSLog.d(TAG, "Modem set " + modemFileName);
                 mConfigurationSet = true;
@@ -236,7 +235,7 @@ public class ModemSwitcher {
         return false;
     }
 
-    public boolean writeModemToMiscTA(String str) {
+    public static boolean writeModemToMiscTA(String str) {
         byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
         byte[] bArr = new byte[(bytes.length + MODEM_MAGIC_COMMAND_LENGTH)];
         bArr[0] = MODEM_MISC_TA_MAGIC1;


### PR DESCRIPTION
Some modem modifications (e.g. O2/Telefonica Germany) work fine upon first boot when the mbn gets applied, but go into a crash cycle at every subsequent reboot unless the boot is performed using 3g only.

This change will make sure that the mbn files get applied at every boot, irrespective of whether the carrier has changed. This will prevent modem crashes from occurring.

At every boot, the modem-switcher will read the 2405 MiscTA unit to determine whether an mbn should be applied - this usually happens only once after a new carrier is detected. If a modem mbn is found, and it differs from the ' current modem ' in TA_FOTA_INTERNAL (unit 2404), the mbn is applied, unit 2405 is cleared and its contents written into unit 2404.