### PR TITLE
Ensure the required mbn is applied at every boot

### DIFF
--- a/res/values-night/styles.xml
+++ b/res/values-night/styles.xml
@@ -1,10 +1,13 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="AppTheme" parent="Theme.MaterialComponents.NoActionBar">
-        <item name="android:windowLightStatusBar">true</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:navigationBarColor">@color/colorPrimary</item>
         <item name="android:navigationBarDividerColor">@color/colorPrimary</item>
+    </style>
+
+    <style name="DialogTheme" parent="Theme.AppCompat.Dialog.Alert">
+        <item name="colorAccent">@color/colorAccent</item>
     </style>
 </resources>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -7,4 +7,8 @@
         <item name="android:navigationBarColor">@color/colorPrimary</item>
         <item name="android:navigationBarDividerColor">@color/colorPrimary</item>
     </style>
+
+    <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
+        <item name="colorAccent">@color/colorAccent</item>
+    </style>
 </resources>

--- a/src-res/com/sonymobile/customizationselector/R.java
+++ b/src-res/com/sonymobile/customizationselector/R.java
@@ -36,6 +36,7 @@ public final class R {
 
     public static final class style {
         public static final int AppTheme = 2653784;
+        public static final int DialogTheme = 2653782;
     }
 
     public static final class xml {

--- a/src/com/sonymobile/customizationselector/CustomizationSelectorService.java
+++ b/src/com/sonymobile/customizationselector/CustomizationSelectorService.java
@@ -45,6 +45,17 @@ public class CustomizationSelectorService extends IntentService {
                 } else {
                     configurator.saveConfigurationKey();
                     CSLog.d(TAG, "isNewConfigurationNeeded - No new configuration.");
+
+                    if (configurator.isFirstApply()) {
+                        context.getPackageManager().setComponentEnabledSetting(new ComponentName(context, CustomizationSelectorActivity.class),
+                                PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.COMPONENT_ENABLED_STATE_ENABLED);
+
+                        if (isUserSetupComplete(context)) {
+                            context.startActivity(new Intent(Intent.ACTION_MAIN, null).addCategory(Intent.CATEGORY_HOME).addFlags(270565376));
+                        }
+                    } else {
+                        configurator.reApplyModem();
+                    }
                 }
             } catch (Exception e) {
                 CSLog.e(TAG, "evaluateCarrierBundle - ERROR: ", e);

--- a/src/com/sonymobile/customizationselector/DSDataSubContentJob.java
+++ b/src/com/sonymobile/customizationselector/DSDataSubContentJob.java
@@ -24,7 +24,7 @@ public class DSDataSubContentJob extends JobService {
     private static final String TAG = DSDataSubContentJob.class.getSimpleName();
     private ConfigurationTask mConfigurationTask;
 
-    private class ConfigurationTask extends AsyncTask<Void, Context, Void> {
+    private static class ConfigurationTask extends AsyncTask<Void, Context, Void> {
         private final Context mContext;
 
         public ConfigurationTask(Context context) {

--- a/src/com/sonymobile/customizationselector/ModemConfiguration.java
+++ b/src/com/sonymobile/customizationselector/ModemConfiguration.java
@@ -47,7 +47,7 @@ public class ModemConfiguration {
     public String getModemConfigurationNeeded(String variant) {
         CSLog.d(TAG, "updateModem - modemVariant = " + variant);
         try {
-            String currentModemConfig = mModemSwitcher.getCurrentModemConfig();
+            String currentModemConfig = ModemSwitcher.getCurrentModemConfig();
             CSLog.d(TAG, "Current modem: " + currentModemConfig);
             if (ModemSwitcher.SINGLE_MODEM_FS.equalsIgnoreCase(currentModemConfig)) {
                 return "";

--- a/src/com/sonymobile/customizationselector/ModemSwitcher.java
+++ b/src/com/sonymobile/customizationselector/ModemSwitcher.java
@@ -169,7 +169,7 @@ public class ModemSwitcher {
         return Arrays.copyOf(mCachedModemConfigurations, mCachedModemConfigurations.length);
     }
 
-    public String getCurrentModemConfig() throws IOException {
+    public static String getCurrentModemConfig() throws IOException {
         ModemStatus readModemAndStatus = readModemAndStatus();
 
         if (readModemAndStatus != null && readModemAndStatus.modemStatusSuccessful) {
@@ -213,7 +213,6 @@ public class ModemSwitcher {
         }
 
         if (hasModemConfig) {
-            String modemFileName;
             try {
                 if (getCurrentModemConfig().equals(modemConfig)) {
                     CSLog.e(TAG, "Selected modem configuration is already active!: " + modemConfig);
@@ -223,7 +222,7 @@ public class ModemSwitcher {
                 CSLog.w(TAG, "Unable to read out current configuration");
             }
 
-            modemFileName = new File(modemConfig).getName();
+            String modemFileName = new File(modemConfig).getName();
             if (writeModemToMiscTA(modemFileName)) {
                 CSLog.d(TAG, "Modem set " + modemFileName);
                 mConfigurationSet = true;
@@ -236,7 +235,7 @@ public class ModemSwitcher {
         return false;
     }
 
-    public boolean writeModemToMiscTA(String str) {
+    public static boolean writeModemToMiscTA(String str) {
         byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
         byte[] bArr = new byte[(bytes.length + MODEM_MAGIC_COMMAND_LENGTH)];
         bArr[0] = MODEM_MISC_TA_MAGIC1;

--- a/src/com/sonymobile/customizationselector/ModemSwitcherActivity.java
+++ b/src/com/sonymobile/customizationselector/ModemSwitcherActivity.java
@@ -60,7 +60,7 @@ public class ModemSwitcherActivity extends Activity {
         mModemSwitcher = new ModemSwitcher();
         try {
             int i2;
-            String currentModem = mModemSwitcher.getCurrentModemConfig().replace(ModemSwitcher.MODEM_FS_PATH, "");
+            String currentModem = ModemSwitcher.getCurrentModemConfig().replace(ModemSwitcher.MODEM_FS_PATH, "");
             CSLog.d(TAG, "current modem" + currentModem);
 
             String[] availableModemConfigurations = mModemSwitcher.getAvailableModemConfigurations();


### PR DESCRIPTION
Some modem modifications (e.g. O2/Telefonica Germany) work fine upon first boot when the mbn gets applied, but go into a crash cycle at every subsequent reboot unless the boot is performed using 3g only.

This change will make sure that the mbn files get applied at every boot, irrespective of whether the carrier has changed. This will prevent modem crashes from occurring.

At every boot, the modem-switcher will read the 2405 MiscTA unit to determine whether an mbn should be applied - this usually happens only once after a new carrier is detected. If a modem mbn is found, and it differs from the ' current modem ' in TA_FOTA_INTERNAL (unit 2404), the mbn is applied, unit 2405 is cleared and its contents written into unit 2404.

Another addition is made here to prompt user to reboot when this CS will be updated on their side so as to execute the re-applying of modem to prevent it's crashing