### PR TITLE
OpenCustomizationSelector: Fill TA_FOTA_INTERNAL with dummy modem name

### DIFF
--- a/src/com/sonymobile/customizationselector/Configurator.java
+++ b/src/com/sonymobile/customizationselector/Configurator.java
@@ -147,7 +147,7 @@ public class Configurator {
                     CSLog.i(TAG, "reApplyModem - 2405 was re-written successfully");
 
                     try {
-                        MiscTA.write(TA_FOTA_INTERNAL, "".getBytes(StandardCharsets.UTF_8));
+                        MiscTA.write(TA_FOTA_INTERNAL, "temporary_modem".getBytes(StandardCharsets.UTF_8));
                         CSLog.i(TAG, "reApplyModem - Modem Switcher 2404 cleared");
                     } catch (MiscTaException e) {
                         CSLog.e(TAG, "reApplyModem - There was an error clearing 2404: ", e);


### PR DESCRIPTION
This is purely cosmetic, avoiding an error message from sony-modem-switcher at boot.
                                                                                                                                         ~ Derf elot