### PR TITLE
OpenCustomizationSelector: Assign 433 custid to S236.1 simid

### DIFF
--- a/res/xml/configuration_selectors.xml
+++ b/res/xml/configuration_selectors.xml
@@ -353,6 +353,7 @@
         <sim_config_id>S237.4</sim_config_id>
     </configuration>
     <configuration config_id="433">
+        <sim_config_id>S236.1</sim_config_id>
         <sim_config_id>S236.2</sim_config_id>
     </configuration>
     <configuration config_id="434">


### PR DESCRIPTION
No idea why Sony doesn't do this in stock, but 433 is for Turkcell and S236.2 is assigned that custid while S236.1 isn't - both are MCC/MNC 286/01.